### PR TITLE
DtD form setting is now hidden until enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 # Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Fixed
+
+-   DtD form setting is now hidden until enabled (#7)

--- a/src/DoubleTheDonation/Assets.php
+++ b/src/DoubleTheDonation/Assets.php
@@ -16,7 +16,13 @@ class Assets {
 	 * @return void
 	 */
 	public static function loadBackendAssets() {
-
+		wp_enqueue_script(
+			'give-double-the-donation-script-backend',
+			GIVE_DTD_URL . 'public/js/give-double-the-donation-admin.js',
+			[],
+			GIVE_DTD_VERSION,
+			true
+		);
 	}
 
 	/**

--- a/src/DoubleTheDonation/SettingsDonationForm.php
+++ b/src/DoubleTheDonation/SettingsDonationForm.php
@@ -37,7 +37,7 @@ class SettingsDonationForm {
 						'give-double-the-donation' ),
 					'type'          => 'text',
 					'default'       => esc_html__( 'See if your company will match your donation!', 'give-double-the-donation' ),
-					'wrapper_class' => 'give-dtd-metabox-field',
+					'wrapper_class' => 'give-dtd-metabox-field give-hidden',
 				],
 				[
 					'name'  => esc_html__( 'Double the Donation Docs Link', 'give-double-the-donation' ),

--- a/src/DoubleTheDonation/resources/js/admin/give-double-the-donation-admin.js
+++ b/src/DoubleTheDonation/resources/js/admin/give-double-the-donation-admin.js
@@ -1,6 +1,6 @@
 
 window.addEventListener('load', () => {
-        
+    
     const updateLabelField = (value) => {
         if (value === 'enabled') {
             document.querySelector('.give_dtd_label_field').classList.remove('give-hidden');

--- a/src/DoubleTheDonation/resources/js/admin/give-double-the-donation-admin.js
+++ b/src/DoubleTheDonation/resources/js/admin/give-double-the-donation-admin.js
@@ -1,0 +1,23 @@
+
+window.addEventListener('load', () => {
+        
+    const updateLabelField = (value) => {
+        if (value === 'enabled') {
+            document.querySelector('.give_dtd_label_field').classList.remove('give-hidden');
+        } else {
+            document.querySelector('.give_dtd_label_field').classList.add('give-hidden');
+        }
+    }
+
+    // Query field used to enable/disable double the donation
+    const enabledField = document.querySelector('.dtd_enable_disable_field');
+
+    // On load, update label field based on enabled field value
+    enabledField && updateLabelField(enabledField.querySelector('input:checked').value);
+
+    // When the enabled field value changes, update label field based on enabled field value
+    enabledField && enabledField.addEventListener('change', (event) => {
+        updateLabelField(event.target.value);
+    });
+
+})


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #3 

## Description
This PR introduces JS logic to toggle visibility of the "Default Label" setting based on whether or not company matching lookup is enabled.

## Affects
This PR affects settings registration and backend JS. From a user perspective, it results in changes to the Company Matching area of form settings.

## Visuals
![HideDtDSetting](https://user-images.githubusercontent.com/5186078/97740054-1181f900-1ab7-11eb-9974-d3f939a3fd24.gif)

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions
1. Add a new donation form
2. Go to the "Comapny Matching" tab of form settings
3. Enable/disable "Employer Search", see that the "Default Label" setting is only visible when enabled.