### PR TITLE
fix: separate even listener to avoid duplicate listeners

### DIFF
--- a/src/DoubleTheDonation/Assets.php
+++ b/src/DoubleTheDonation/Assets.php
@@ -32,18 +32,24 @@ class Assets {
 	 * @return void
 	 */
 	public static function loadFrontendAssets() {
-
 		wp_enqueue_script(
-			'give-double-the-donation-style-script',
+			'give-double-the-donation-script',
 			'https://doublethedonation.com/api/js/ddplugin.js',
 			[]
 		);
+
 		wp_enqueue_style(
 			'give-double-the-donation-style',
 			'https://doublethedonation.com/api/css/ddplugin.css',
 			[]
 		);
 
-
+		wp_enqueue_script(
+			'give-double-the-donation-script-backend',
+			GIVE_DTD_URL . 'public/js/give-double-the-donation.js',
+			['give-double-the-donation-script'],
+			GIVE_DTD_VERSION,
+			true
+		);
 	}
 }

--- a/src/DoubleTheDonation/Assets.php
+++ b/src/DoubleTheDonation/Assets.php
@@ -45,7 +45,7 @@ class Assets {
 		);
 
 		wp_enqueue_script(
-			'give-double-the-donation-script-backend',
+			'give-double-the-donation-script-frontend',
 			GIVE_DTD_URL . 'public/js/give-double-the-donation.js',
 			['give-double-the-donation-script'],
 			GIVE_DTD_VERSION,

--- a/src/DoubleTheDonation/DonationForm.php
+++ b/src/DoubleTheDonation/DonationForm.php
@@ -33,16 +33,13 @@ class DonationForm {
 		?>
 
 		<div class="give-double-the-donation-wrap form-row form-row-wide" <?php echo $divStyle; ?>>
+			<label class="give-label" for="give-first" <?php echo $labelStyle ?>><?php echo $dtdLabel; ?></label>
+			<div id="dd-company-name-input"></div>
 			<script>
 				if ( window.doublethedonation ) {
 					var DDCONF = { 'API_KEY': '<?php echo $dtdPublicKey; ?>' };
-					document.addEventListener( 'give_gateway_loaded', ( e ) => {
-						doublethedonation.plugin.load_streamlined_input();
-					} );
 				}
 			</script>
-			<label class="give-label" for="give-first" <?php echo $labelStyle ?>><?php echo $dtdLabel; ?></label>
-			<div id="dd-company-name-input"></div>
 		</div>
 		<?php
 	}

--- a/src/DoubleTheDonation/DonationForm.php
+++ b/src/DoubleTheDonation/DonationForm.php
@@ -34,7 +34,7 @@ class DonationForm {
 
 		<div class="give-double-the-donation-wrap form-row form-row-wide" <?php echo $divStyle; ?>>
 			<label class="give-label" for="give-first" <?php echo $labelStyle ?>><?php echo $dtdLabel; ?></label>
-			<div id="dd-company-name-input"></div>
+			<div class="dd-company-name-input"></div>
 			<script>
 				if ( window.doublethedonation ) {
 					var DDCONF = { 'API_KEY': '<?php echo $dtdPublicKey; ?>' };

--- a/src/DoubleTheDonation/DonationForm.php
+++ b/src/DoubleTheDonation/DonationForm.php
@@ -25,9 +25,9 @@ class DonationForm {
 		}
 
 		// Do not handle legacy donation form.
-		$labelStyle = ! FormUtils::isLegacyForm() ? 'style="display: block !important; font-size: 14px;"'  : '';
-		$divStyle = ! FormUtils::isLegacyForm() ? 'style="margin: 0 0 20px;"'  : '';
-
+		$isLegacyForm = FormUtils::isLegacyForm();
+		$labelStyle = ! $isLegacyForm ? 'style="display: block !important; font-size: 14px;"'  : '';
+		$divStyle = ! $isLegacyForm ? 'style="margin: 0 0 20px;"'  : '';
 
 		$dtdLabel = give_get_meta( $form_id, 'give_dtd_label', true, esc_html__( 'See if your company will match your donation!', 'give-double-the-donation' ) );
 		?>

--- a/src/DoubleTheDonation/resources/js/frontend/give-double-the-donation.js
+++ b/src/DoubleTheDonation/resources/js/frontend/give-double-the-donation.js
@@ -1,0 +1,5 @@
+if ( window.doublethedonation ) {
+	document.addEventListener( 'give_gateway_loaded', () => {
+		window.doublethedonation.plugin.load_streamlined_input();
+	} );
+}

--- a/src/DoubleTheDonation/resources/js/frontend/give-double-the-donation.js
+++ b/src/DoubleTheDonation/resources/js/frontend/give-double-the-donation.js
@@ -1,9 +1,13 @@
 if ( window.doublethedonation ) {
-	document.addEventListener( 'give_gateway_loaded', () => {
-		const input = document.getElementById( 'dd-company-name-input' );
+	function initializePlugin() {
+		document.querySelectorAll( '.dd-company-name-input' ).forEach( ( input ) => {
+			if ( ! input.hasAttribute( 'data-doublethedonation-widget-id' ) ) {
+				window.doublethedonation.plugin.load_streamlined_input( input );
+			}
+		} );
+	}
 
-		if ( ! input.hasAttribute( 'data-doublethedonation-widget-id' ) ) {
-			window.doublethedonation.plugin.load_streamlined_input();
-		}
-	} );
+	document.addEventListener( 'give_gateway_loaded', initializePlugin );
+
+	initializePlugin();
 }

--- a/src/DoubleTheDonation/resources/js/frontend/give-double-the-donation.js
+++ b/src/DoubleTheDonation/resources/js/frontend/give-double-the-donation.js
@@ -1,5 +1,9 @@
 if ( window.doublethedonation ) {
 	document.addEventListener( 'give_gateway_loaded', () => {
-		window.doublethedonation.plugin.load_streamlined_input();
+		const input = document.getElementById( 'dd-company-name-input' );
+
+		if ( ! input.hasAttribute( 'data-doublethedonation-widget-id' ) ) {
+			window.doublethedonation.plugin.load_streamlined_input();
+		}
 	} );
 }


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #11 

## Description

On the legacy form there was an issue where the company selection dropdown stopped working if another gateway was selected within the form. The issue behind this was that every time the gateway was changed a new script was sent over which attached and additional listener for when the gateway changed. Since the gateway was never removed, every time the gateway changed another listener was attached and fired. This means the initialization for the DtD plugin was being called every time, which caused issues.

This pulls out the event listener into its own script so that it's only attached once per page, so it only fires one time. This resolved the overlying issue.

As a bonus, I also noticed that IDs were being used to select for input fields. This means that multiple legacy forms on a page could not use this add-on. I went ahead and changed the selector to a class (and tweaked the JS) so it's no longer an issue.

## Affects

Legacy and multi-step forms using this add-on.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changes logged to the `Unreleased` section of `CHANGELOG.md`
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

1. Create multi-step and legacy forms
2. Enable this add-on for each form
3. In each form, try setting a company, changing gateways, and setting it again
4. In each form, try changing gateways (without setting a company) and then setting the company
