### PR TITLE
Fix: prevent field from showing up twice

### DIFF
--- a/src/DoubleTheDonation/AddonServiceProvider.php
+++ b/src/DoubleTheDonation/AddonServiceProvider.php
@@ -33,7 +33,7 @@ class AddonServiceProvider implements ServiceProvider {
 	public function boot() {
 		// Load add-on translations.
 		Hooks::addAction( 'init', Language::class, 'load' );
-		Hooks::addAction( 'give_donation_form_user_info', DonationForm::class, 'employerMatchField' );
+		Hooks::addAction( 'give_donation_form_after_email', DonationForm::class, 'employerMatchField' );
 
 		Hooks::addAction( 'give_insert_payment', Payment::class, 'addPaymentMeta', 10, 2 );
 		Hooks::addAction( 'give_insert_payment', Payment::class, 'addDonationToDTD', 11, 2 );


### PR DESCRIPTION
The previous hook was causing the additional field to display multiple times. This hook only displays once.

<!-- Make sure to prefix the title with one of New:, Fix:, Changed:, or Security: -->

<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #15

## Description

Before, when logged-out visitors viewed a form, if registration and login fields were enabled, the DtD search field displayed twice. Now it does not.
## Affects

The location of the output

## Visuals

![image](https://user-images.githubusercontent.com/9629102/175093999-dc6f51c8-1f7f-4f60-b534-96b061b174ce.png)


## Testing Instructions

1. Install GiveWP
1. Install this PR
1. Put in our test credentials in the DtD settings (contact Me on Slack for those credentials)
1. Create a form (any template) and navigate in that form's settings to the form Fields tab
1. Enable either the "login" or "registration + Login" option. (see image)
1. Save or publish the form.
1. Visit the front end of the form.
1. For Classic and legacy, scroll to see that the DtD field is added twice as in the image on the original post. For Multistep, click through to the appropriate step of the form.

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [ ] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit and/or end-to-end tests
-   [ ] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

