### PR TITLE
Refactor: improve V2/V3 form handling and add comprehensive API logging

### DIFF
--- a/src/DoubleTheDonation/Actions/RegisterDonationOnDTD.php
+++ b/src/DoubleTheDonation/Actions/RegisterDonationOnDTD.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace GiveDoubleTheDonation\DoubleTheDonation\Actions;
+
+use Give\Donations\Models\Donation;
+use Give\Helpers\Form\Utils;
+use Give\Log\Log;
+use GiveDoubleTheDonation\DoubleTheDonation\Payment;
+
+class RegisterDonationOnDTD {
+    public function __invoke($payment_id, $payment_data) {
+        // V3 forms are handled by the field scope
+        if (!isset($_POST) || Utils::isV3Form((int)$payment_data['give_form_id'])) {
+            if (defined('WP_DEBUG') && WP_DEBUG) {
+                Log::warning(
+                    'Double the Donation: Skipping donation registration for V3 form',
+                    [
+                        'category' => 'Payment',
+                        'source' => 'Double the Donation add-on',
+                        'payment_id' => $payment_id,
+                    ]
+                );
+            }
+
+            return;
+        }
+
+        give(Payment::class)->addPaymentMeta($payment_id, $payment_data);
+
+        $donation = Donation::find((int)$payment_id);
+
+        // handle for single donations only
+        if ($donation->type->isSingle()) {
+            give(Payment::class)->addDonationToDTD($payment_id, $payment_data);
+        }
+    }
+}

--- a/src/DoubleTheDonation/Actions/RegisterDonationOnDTD.php
+++ b/src/DoubleTheDonation/Actions/RegisterDonationOnDTD.php
@@ -7,20 +7,26 @@ use Give\Helpers\Form\Utils;
 use Give\Log\Log;
 use GiveDoubleTheDonation\DoubleTheDonation\Payment;
 
+/**
+ * @unreleased
+ */
 class RegisterDonationOnDTD {
+    /**
+     * Called on give_insert_payment action.
+     *
+     * @unreleased
+     */
     public function __invoke($payment_id, $payment_data) {
         // V3 forms are handled by the field scope
         if (!isset($_POST) || Utils::isV3Form((int)$payment_data['give_form_id'])) {
-            if (defined('WP_DEBUG') && WP_DEBUG) {
-                Log::warning(
-                    'Double the Donation: Skipping donation registration for V3 form',
-                    [
-                        'category' => 'Payment',
-                        'source' => 'Double the Donation add-on',
-                        'payment_id' => $payment_id,
-                    ]
-                );
-            }
+            Log::info(
+                'Double the Donation: Skipping donation registration for V3 form',
+                [
+                    'category' => 'Payment',
+                    'source' => 'Double the Donation add-on',
+                    'payment_id' => $payment_id,
+                ]
+            );
 
             return;
         }

--- a/src/DoubleTheDonation/Actions/RegisterRecurringDonationOnDTD.php
+++ b/src/DoubleTheDonation/Actions/RegisterRecurringDonationOnDTD.php
@@ -5,7 +5,15 @@ namespace GiveDoubleTheDonation\DoubleTheDonation\Actions;
 use GiveDoubleTheDonation\DoubleTheDonation\Payment;
 use Give_Payment;
 
+/**
+ * @unreleased
+ */
 class RegisterRecurringDonationOnDTD {
+    /**
+     * Called on give_recurring_record_payment action.
+     *
+     * @unreleased
+     */
     public function __invoke(Give_Payment $payment) {
         give(Payment::class)->addDonationToDTD($payment->ID, $payment);
     }

--- a/src/DoubleTheDonation/Actions/RegisterRecurringDonationOnDTD.php
+++ b/src/DoubleTheDonation/Actions/RegisterRecurringDonationOnDTD.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace GiveDoubleTheDonation\DoubleTheDonation\Actions;
+
+use GiveDoubleTheDonation\DoubleTheDonation\Payment;
+use Give_Payment;
+
+class RegisterRecurringDonationOnDTD {
+    public function __invoke(Give_Payment $payment) {
+        give(Payment::class)->addDonationToDTD($payment->ID, $payment);
+    }
+}

--- a/src/DoubleTheDonation/AddonServiceProvider.php
+++ b/src/DoubleTheDonation/AddonServiceProvider.php
@@ -10,6 +10,7 @@ use GiveDoubleTheDonation\Addon\Language;
 use GiveDoubleTheDonation\Addon\License;
 use GiveDoubleTheDonation\DoubleTheDonation\Actions\CheckCredentials;
 use GiveDoubleTheDonation\DoubleTheDonation\Actions\RegisterDonationOnDTD;
+use GiveDoubleTheDonation\DoubleTheDonation\Actions\RegisterRecurringDonationOnDTD;
 use GiveDoubleTheDonation\DoubleTheDonation\API\REST\CompanyMatching;
 use GiveDoubleTheDonation\DoubleTheDonation\Helpers\SettingsPage as SettingsPageRegister;
 
@@ -40,11 +41,7 @@ class AddonServiceProvider implements ServiceProvider
 
         Hooks::addAction('give_donation_form_after_email', DonationForm::class, 'employerMatchField');
         Hooks::addAction('give_insert_payment', RegisterDonationOnDTD::class, '__invoke', 10, 2);
-
-        /**
-         * @since 2.1.0 add support for recurring donations
-         */
-        Hooks::addAction('give_recurring_record_payment', Payment::class, 'addDonationToDTD', 10, 2);
+        Hooks::addAction('give_recurring_record_payment', RegisterRecurringDonationOnDTD::class);
 
         // Show Receipt info
         Hooks::addAction('give_payment_receipt_after', UpdateDonationReceipt::class, 'renderLegacyRow', 10, 2);

--- a/src/DoubleTheDonation/FormExtension/Actions/FieldScope/HandleData.php
+++ b/src/DoubleTheDonation/FormExtension/Actions/FieldScope/HandleData.php
@@ -106,6 +106,7 @@ class HandleData
             'campaign' => $donation->formId,
             'donation_amount' => $donation->amount->formatToDecimal(),
             'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
+            'recurring' => $donation->type->isRecurring(),
             'partner_identifier' => 'GiveWP',
         ];
 
@@ -127,6 +128,7 @@ class HandleData
                     'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
                     'company_id' => $companyData['company_id'],
                     'company_name' => $companyData['company_name'],
+                    'data' => $data,
                 ]
             );
         }

--- a/src/DoubleTheDonation/FormExtension/Actions/FieldScope/HandleData.php
+++ b/src/DoubleTheDonation/FormExtension/Actions/FieldScope/HandleData.php
@@ -78,6 +78,7 @@ class HandleData
     /**
      * Send data to DTD 360match pro
      *
+     * @unreleased add logging
      * @since 2.1.0 update visibility
      * @since 2.0.2
      */
@@ -118,20 +119,18 @@ class HandleData
             $data['doublethedonation_entered_text'] = $companyData['entered_text'];
         }
 
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            Log::info(
-                'Double the Donation: Sending donation data to 360MatchPro API',
-                [
-                    'category' => 'Payment',
-                    'source' => 'Double the Donation add-on',
-                    'donation_id' => $donation->id,
-                    'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
-                    'company_id' => $companyData['company_id'],
-                    'company_name' => $companyData['company_name'],
-                    'data' => $data,
-                ]
-            );
-        }
+        Log::info(
+            'Double the Donation: Sending donation data to 360MatchPro API',
+            [
+                'category' => 'Payment',
+                'source' => 'Double the Donation add-on',
+                'donation_id' => $donation->id,
+                'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
+                'company_id' => $companyData['company_id'],
+                'company_name' => $companyData['company_name'],
+                'data' => $data,
+            ]
+        );
 
         $response = wp_remote_post('https://doublethedonation.com/api/360matchpro/v1/register_donation',
             [
@@ -152,26 +151,24 @@ class HandleData
         $responseHeadersArray = (is_wp_error($response) || ! $responseHeaders || ! method_exists($responseHeaders, 'getAll')) ? [] : $responseHeaders->getAll();
 
         // Log the raw response from the server
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            Log::http(
-                'Double the Donation: Received response from 360MatchPro API',
-                [
-                    'category' => 'Payment',
-                    'source' => 'Double the Donation add-on',
-                    'donation_id' => $donation->id,
-                    'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
-                    'response_code' => $responseCode,
-                    'response_message' => $responseMessage,
-                    'response_headers' => $responseHeadersArray,
-                    'response_body' => $responseBody,
-                    'raw_response' => is_wp_error($response) ? [
-                        'error_code' => $response->get_error_code(),
-                        'error_message' => $response->get_error_message(),
-                        'error_data' => $response->get_error_data(),
-                    ] : $response,
-                ]
-            );
-        }
+        Log::http(
+            'Double the Donation: Received response from 360MatchPro API',
+            [
+                'category' => 'Payment',
+                'source' => 'Double the Donation add-on',
+                'donation_id' => $donation->id,
+                'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
+                'response_code' => $responseCode,
+                'response_message' => $responseMessage,
+                'response_headers' => $responseHeadersArray,
+                'response_body' => $responseBody,
+                'raw_response' => is_wp_error($response) ? [
+                    'error_code' => $response->get_error_code(),
+                    'error_message' => $response->get_error_message(),
+                    'error_data' => $response->get_error_data(),
+                ] : $response,
+            ]
+        );
 
         // API fail check.
         if (201 !== $responseCode) {
@@ -198,23 +195,21 @@ class HandleData
             return;
         }
 
-        if (defined('WP_DEBUG') && WP_DEBUG) {
-            Log::success(
-                'Double the Donation: Successfully registered donation with 360MatchPro API',
-                [
-                    'category' => 'Payment',
-                    'source' => 'Double the Donation add-on',
-                    'donation_id' => $donation->id,
-                    'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
-                    'response_code' => $responseCode,
-                    'response_message' => $responseMessage,
-                    'response_headers' => $responseHeadersArray,
-                    'response_body' => $responseBody,
-                    'company_id' => $companyData['company_id'],
-                    'company_name' => $companyData['company_name'],
-                ]
-            );
-        }
+        Log::success(
+            'Double the Donation: Successfully registered donation with 360MatchPro API',
+            [
+                'category' => 'Payment',
+                'source' => 'Double the Donation add-on',
+                'donation_id' => $donation->id,
+                'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
+                'response_code' => $responseCode,
+                'response_message' => $responseMessage,
+                'response_headers' => $responseHeadersArray,
+                'response_body' => $responseBody,
+                'company_id' => $companyData['company_id'],
+                'company_name' => $companyData['company_name'],
+            ]
+        );
 
         DonationNote::create([
             'donationId' => $donation->id,

--- a/src/DoubleTheDonation/FormExtension/Actions/FieldScope/HandleData.php
+++ b/src/DoubleTheDonation/FormExtension/Actions/FieldScope/HandleData.php
@@ -30,7 +30,7 @@ class HandleData
                         'category' => 'Payment',
                         'source' => 'Double the Donation add-on',
                         'donation_id' => $donation->id,
-                        'donation_identifier' => $donation->getSequentialId(),
+                        'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
                         'company_data' => is_array($company) ? [
                             'company_id' => $company['company_id'] ?? null,
                             'company_name' => $company['company_name'] ?? null,
@@ -105,7 +105,7 @@ class HandleData
             'donor_email' => $donation->email,
             'campaign' => $donation->formId,
             'donation_amount' => $donation->amount->formatToDecimal(),
-            'donation_identifier' => $donation->getSequentialId(),
+            'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
             'partner_identifier' => 'GiveWP',
         ];
 
@@ -124,7 +124,7 @@ class HandleData
                     'category' => 'Payment',
                     'source' => 'Double the Donation add-on',
                     'donation_id' => $donation->id,
-                    'donation_identifier' => $donation->getSequentialId(),
+                    'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
                     'company_id' => $companyData['company_id'],
                     'company_name' => $companyData['company_name'],
                 ]
@@ -157,7 +157,7 @@ class HandleData
                     'category' => 'Payment',
                     'source' => 'Double the Donation add-on',
                     'donation_id' => $donation->id,
-                    'donation_identifier' => $donation->getSequentialId(),
+                    'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
                     'response_code' => $responseCode,
                     'response_message' => $responseMessage,
                     'response_headers' => $responseHeadersArray,
@@ -179,7 +179,7 @@ class HandleData
                     'category' => 'Payment',
                     'source' => 'Double the Donation add-on',
                     'donation_id' => $donation->id,
-                    'donation_identifier' => $donation->getSequentialId(),
+                    'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
                     'response_code' => $responseCode,
                     'response_message' => $responseMessage,
                     'response_headers' => $responseHeadersArray,
@@ -203,7 +203,7 @@ class HandleData
                     'category' => 'Payment',
                     'source' => 'Double the Donation add-on',
                     'donation_id' => $donation->id,
-                    'donation_identifier' => $donation->getSequentialId(),
+                    'donation_identifier' => $donation->getSequentialId() ?? $donation->id,
                     'response_code' => $responseCode,
                     'response_message' => $responseMessage,
                     'response_headers' => $responseHeadersArray,

--- a/src/DoubleTheDonation/Payment.php
+++ b/src/DoubleTheDonation/Payment.php
@@ -2,6 +2,7 @@
 
 namespace GiveDoubleTheDonation\DoubleTheDonation;
 
+use Give\Donations\ValueObjects\DonationMetaKeys;
 use Give\Log\Log;
 
 class Payment {
@@ -81,7 +82,7 @@ class Payment {
 			'campaign'               => $paymentMeta['form_id'],
 			'donation_amount'        => give_donation_amount( $payment_id ),
 			'donation_identifier'    => $donationIdentifier,
-			'recurring'              => $payment_data->is_recurring(),
+			'recurring'              => (bool)$paymentMeta[DonationMetaKeys::IS_RECURRING],
 			'partner_identifier'     => 'GiveWP',
 		];
 

--- a/src/DoubleTheDonation/Payment.php
+++ b/src/DoubleTheDonation/Payment.php
@@ -81,6 +81,7 @@ class Payment {
 			'campaign'               => $paymentMeta['form_id'],
 			'donation_amount'        => give_donation_amount( $payment_id ),
 			'donation_identifier'    => $donationIdentifier,
+			'recurring'              => $payment_data->is_recurring(),
 			'partner_identifier'     => 'GiveWP',
 		];
 
@@ -104,6 +105,7 @@ class Payment {
 					'donation_identifier' => $donationIdentifier,
 					'company_id'         => $companyID,
 					'company_name'       => isset( $paymentMeta['doublethedonation_company_name'] ) ? $paymentMeta['doublethedonation_company_name'] : null,
+                    'data'               => $data_360,
 				]
 			);
 		}

--- a/src/DoubleTheDonation/Payment.php
+++ b/src/DoubleTheDonation/Payment.php
@@ -47,6 +47,9 @@ class Payment {
 
 	/**
 	 * Adds the donation to DTD.
+     *
+     * @unreleased add logging
+     * @since 1.0.0
 	 *
 	 * @param $payment_id
 	 * @param $payment_data
@@ -96,20 +99,18 @@ class Payment {
 			$data_360['doublethedonation_entered_text'] = $companyEnteredText;
 		}
 
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			Log::info(
-				'Double the Donation: Sending donation data to 360MatchPro API',
-				[
-					'category'           => 'Payment',
-					'source'             => 'Double the Donation add-on',
-					'payment_id'         => $payment_id,
-					'donation_identifier' => $donationIdentifier,
-					'company_id'         => $companyID,
-					'company_name'       => isset( $paymentMeta['doublethedonation_company_name'] ) ? $paymentMeta['doublethedonation_company_name'] : null,
-                    'data'               => $data_360,
-				]
-			);
-		}
+        Log::info(
+            'Double the Donation: Sending donation data to 360MatchPro API',
+            [
+                'category'           => 'Payment',
+                'source'             => 'Double the Donation add-on',
+                'payment_id'         => $payment_id,
+                'donation_identifier' => $donationIdentifier,
+                'company_id'         => $companyID,
+                'company_name'       => isset( $paymentMeta['doublethedonation_company_name'] ) ? $paymentMeta['doublethedonation_company_name'] : null,
+                'data'               => $data_360,
+            ]
+        );
 
 		// Pass donation data to DTD regardless of whether the donor put donor information
 		// this is requested by DTD because they have in their system matching processes for donation data.
@@ -131,26 +132,24 @@ class Payment {
 		$responseHeadersArray = ( is_wp_error( $response ) || ! $responseHeaders || ! method_exists( $responseHeaders, 'getAll' ) ) ? [] : $responseHeaders->getAll();
 
 		// Log the raw response from the server
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			Log::http(
-				'Double the Donation: Received response from 360MatchPro API',
-				[
-					'category'           => 'Payment',
-					'source'             => 'Double the Donation add-on',
-					'payment_id'         => $payment_id,
-					'donation_identifier' => $donationIdentifier,
-					'response_code'      => $responseCode,
-					'response_message'  => $responseMessage,
-					'response_headers'  => $responseHeadersArray,
-					'response_body'     => $responseBodyArray,
-					'raw_response'      => is_wp_error( $response ) ? [
-						'error_code'    => $response->get_error_code(),
-						'error_message' => $response->get_error_message(),
-						'error_data'    => $response->get_error_data(),
-					] : $response,
-				]
-			);
-		}
+        Log::http(
+            'Double the Donation: Received response from 360MatchPro API',
+            [
+                'category'           => 'Payment',
+                'source'             => 'Double the Donation add-on',
+                'payment_id'         => $payment_id,
+                'donation_identifier' => $donationIdentifier,
+                'response_code'      => $responseCode,
+                'response_message'  => $responseMessage,
+                'response_headers'  => $responseHeadersArray,
+                'response_body'     => $responseBodyArray,
+                'raw_response'      => is_wp_error( $response ) ? [
+                    'error_code'    => $response->get_error_code(),
+                    'error_message' => $response->get_error_message(),
+                    'error_data'    => $response->get_error_data(),
+                ] : $response,
+            ]
+        );
 
 		// API fail check.
 		if ( 201 !== $responseCode ) {
@@ -180,25 +179,23 @@ class Payment {
 			return false;
 		}
 
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$matchedCompanyId = isset( $responseBody->{'matched-company'}->id ) ? $responseBody->{'matched-company'}->id : null;
+        $matchedCompanyId = isset( $responseBody->{'matched-company'}->id ) ? $responseBody->{'matched-company'}->id : null;
 
-			Log::success(
-				'Double the Donation: Successfully registered donation with 360MatchPro API',
-				[
-					'category'           => 'Payment',
-					'source'             => 'Double the Donation add-on',
-					'payment_id'         => $payment_id,
-					'donation_identifier' => $donationIdentifier,
-					'response_code'      => $responseCode,
-					'response_message'  => $responseMessage,
-					'response_headers'  => $responseHeadersArray,
-					'response_body'     => $responseBodyArray,
-					'company_id'         => $companyID,
-					'matched_company_id' => $matchedCompanyId,
-				]
-			);
-		}
+        Log::success(
+            'Double the Donation: Successfully registered donation with 360MatchPro API',
+            [
+                'category'           => 'Payment',
+                'source'             => 'Double the Donation add-on',
+                'payment_id'         => $payment_id,
+                'donation_identifier' => $donationIdentifier,
+                'response_code'      => $responseCode,
+                'response_message'  => $responseMessage,
+                'response_headers'  => $responseHeadersArray,
+                'response_body'     => $responseBodyArray,
+                'company_id'         => $companyID,
+                'matched_company_id' => $matchedCompanyId,
+            ]
+        );
 
 		// Success! Add note for admin.
 		$note = esc_html__( 'Donation information added to Double the Donation 360MatchPro', 'give-double-the-donation' );

--- a/src/DoubleTheDonation/resources/views/dtd-receipt.php
+++ b/src/DoubleTheDonation/resources/views/dtd-receipt.php
@@ -11,6 +11,9 @@ use GiveDoubleTheDonation\DoubleTheDonation\Helpers\DoubleTheDonationApi;
 $companyId = give_get_meta($donation->id, 'doublethedonation_company_id', true);
 
 if ( ! $companyId) {
+    /*
+     * Reverted ability to edit company name in the receipt due to current DTD API restrictions.
+     */
     // printf('<div class="dd-company-name-input" data-donation-id="%s" data-receipt-id="%s"></div>', $donation->id, $receiptId);
     return;
 }

--- a/src/DoubleTheDonation/resources/views/dtd-receipt.php
+++ b/src/DoubleTheDonation/resources/views/dtd-receipt.php
@@ -11,7 +11,7 @@ use GiveDoubleTheDonation\DoubleTheDonation\Helpers\DoubleTheDonationApi;
 $companyId = give_get_meta($donation->id, 'doublethedonation_company_id', true);
 
 if ( ! $companyId) {
-    printf('<div class="dd-company-name-input" data-donation-id="%s" data-receipt-id="%s"></div>', $donation->id, $receiptId);
+    // printf('<div class="dd-company-name-input" data-donation-id="%s" data-receipt-id="%s"></div>', $donation->id, $receiptId);
     return;
 }
 


### PR DESCRIPTION
Resolve [GIVE-3015]

## Description

This PR refactors the Double the Donation integration to better separate V2 and V3 form handling, adds comprehensive logging for API requests, fixes bugs with sequential donation IDs and recurring donations, and reverts a feature for company selection on the confirmation page.

### Key Changes

1. **Refactor: Extract V2 form handler to dedicated action class**
   - Created new `RegisterDonationOnDTD` action class to handle V2 form donations
   - Moved inline closure from `AddonServiceProvider` to a dedicated, testable class
   - Improved separation of concerns between V2 and V3 form handling

2. **Debug: Add comprehensive logging for API requests**
   - Added detailed logging to both V2 (`Payment.php`) and V3 (`HandleData.php`) handlers
   - Logs include request data, response codes, headers, and body
   - Logging only enabled when `WP_DEBUG_LOG` is true
   - Improved error messages with structured context data

3. **Fix: Use donation ID as fallback for sequential ID**
   - Added fallback logic to use donation ID when sequential ID is not available
   - Prevents API failures when sequential numbering is disabled or unavailable
   - Applied to both V2 and V3 form handlers

4. **Fix: Implement proper handling for recurring donations**
   - Created new `RegisterRecurringDonationOnDTD` action class to handle recurring donations
   - Refactored recurring donation hook to use dedicated action class instead of calling Payment directly
   - Added `recurring` flag to API data array for both V2 and V3 handlers
   - Improved logging context to include full data array

5. **Chore: Revert company selection on confirmation page**
   - Removed the ability to select a company on the donation receipt page
   - Commented out the company name input component

## Affects

- V2 form donation processing (now handled by dedicated action class)
- V3 form donation processing (improved error handling and logging)
- Recurring donation processing (now handled by dedicated action class)
- API request logging and debugging capabilities
- Sequential donation ID handling
- Recurring donation flag in API payload

## Testing Instructions

1. **Test V2 Form Donations:**
   - Create a donation using a V2 form with company matching
   - Verify donation is registered with Double the Donation API
   - Check logs (when `WP_DEBUG_LOG` is enabled) for API request/response details

2. **Test V3 Form Donations:**
   - Create a donation using a V3 form with company matching
   - Verify donation is registered with Double the Donation API
   - Check logs (when `WP_DEBUG_LOG` is enabled) for API request/response details

3. **Test Sequential ID Fallback:**
   - Disable sequential donation numbering in GiveWP settings
   - Create a donation and verify it still registers with Double the Donation API
   - Verify donation ID is used instead of sequential ID in API calls

4. **Test Recurring Donations:**
   - Create a recurring donation with company matching
   - Verify recurring donations are registered with Double the Donation API
   - Verify the `recurring` flag is included in the API payload
   - Check that recurring donation renewals are properly handled

5. **Test Logging:**
   - Enable `WP_DEBUG_LOG` in `wp-config.php`
   - Create donations with both V2 and V3 forms (including recurring)
   - Verify detailed logs are created in GiveWP logs for API requests/responses
   - Verify logs include the full data array in the context
   - Disable `WP_DEBUG_LOG` in `wp-config.php`
   - Repeat the tests and verify that the logs do not include any debug-related information

6. **Verify Company Selection Removal:**
   - View a donation receipt page
   - Verify company selection input is no longer displayed

## Pre-review Checklist

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] Self Review of code and UX completed

[GIVE-3015]: https://stellarwp.atlassian.net/browse/GIVE-3015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ